### PR TITLE
Add properties to allow Hazelcast differentiate which service-name/family should be serving inside a ECS fargate cluster

### DIFF
--- a/MoquiConf.xml
+++ b/MoquiConf.xml
@@ -21,6 +21,9 @@
     <default-property name="hazelcast_aws_tag_value" value=""/>
     <default-property name="hazelcast_aws_host_header" value="ec2.amazonaws.com"/>
     <default-property name="hazelcast_aws_hz_port" value="5701"/>
+    <default-property name="hazelcast_aws_service_name" value=""/>
+    <default-property name="hazelcast_aws_family" value=""/>
+    <default-property name="hazelcast_aws_cluster" value=""/>
 
     <default-property name="hazelcast_interfaces_enabled" value="false"/>
     <default-property name="hazelcast_interface1" value=""/>

--- a/src/main/groovy/org/moqui/hazelcast/HazelcastToolFactory.groovy
+++ b/src/main/groovy/org/moqui/hazelcast/HazelcastToolFactory.groovy
@@ -114,6 +114,9 @@ class HazelcastToolFactory implements ToolFactory<HazelcastInstance> {
             if (System.getProperty("hazelcast_aws_security_group")) properties.put("security-group-name", System.getProperty("hazelcast_aws_security_group"))
             if (System.getProperty("hazelcast_aws_tag_key")) properties.put("tag-key", System.getProperty("hazelcast_aws_tag_key"))
             if (System.getProperty("hazelcast_aws_tag_value")) properties.put("tag-value", System.getProperty("hazelcast_aws_tag_value"))
+            if (System.getProperty("hazelcast_aws_service_name")) properties.put("service-name", System.getProperty("hazelcast_aws_service_name"))
+            if (System.getProperty("hazelcast_aws_family")) properties.put("family", System.getProperty("hazelcast_aws_family"))
+            if (System.getProperty("hazelcast_aws_cluster")) properties.put("cluster", System.getProperty("hazelcast_aws_cluster"))
             properties.put("hz-port",System.getProperty("hazelcast_aws_hz_port") ?: "5701")
 
             DiscoveryStrategyConfig discoveryStrategyConfig = new DiscoveryStrategyConfig(awsDiscoveryStrategyFactory, properties)

--- a/src/main/resources/hazelcast.xml
+++ b/src/main/resources/hazelcast.xml
@@ -51,6 +51,9 @@
                         <property name="tag-key">{hazelcast_aws_tag_key}</property>
                         <property name="tag-value">{hazelcast_aws_tag_value}</property>
                         <property name="hz-port">{hazelcast_aws_hz_port}</property>
+                        <property name="service-name">{hazelcast_aws_service_name}</property>
+                        <property name="family">{hazelcast_aws_family}</property>
+                        <property name="cluster">{hazelcast_aws_cluster}</property>
                     </properties>
                 </discovery-strategy>
             </discovery-strategies>


### PR DESCRIPTION
We tested moqui-hazelcast in ECS Fargate cluster and find out that when instances are running in the same cluster, Hazelcast can't differentiate which service-name/family is serving. This PR proposes to include properties for cluster, service-name, and family in an ECS Fargate cluster. These parameters are optional according to https://github.com/hazelcast/hazelcast-aws but helpful to choose from different clusters, service-name, and family in the same VPC.