### PR TITLE
Add properties to allow Hazelcast differentiate which service-name/family should be serving inside a ECS fargate cluster - Sign AUTHORS file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,6 +36,7 @@ Signed by git commit adding my legal name and git username:
 
 Written in 2010-2016 by David E. Jones - jonesde
 Written in 2020 by Jens Hardings - jenshp
+Written in 2020 by Ricardo Peláez Negro - rpnegro
 
 ===========================================================================
 
@@ -59,4 +60,4 @@ Signed by git commit adding my legal name and git username:
 
 Written in 2010-2016 by David E. Jones - jonesde
 Written in 2020 by Jens Hardings - jenshp
-
+Written in 2020 by Ricardo Peláez Negro - rpnegro


### PR DESCRIPTION
We tested moqui-hazelcast in ECS Fargate cluster and find out that when instances are running in the same cluster, Hazelcast can't differentiate which service-name/family is serving. This PR proposes to include properties for cluster, service-name, and family in an ECS Fargate cluster. These parameters are optional according to https://github.com/hazelcast/hazelcast-aws but helpful to choose from different clusters, service-name, and family in the same VPC.

Sign the AUTHORS file.